### PR TITLE
Editor View Only

### DIFF
--- a/sources/shdr/App.coffee
+++ b/sources/shdr/App.coffee
@@ -20,6 +20,8 @@ class App
     @extend(@conf, conf)
     @ui = new shdr.UI(@)
     return if not @initViewer(domCanvas)
+    if window.location.search.substring(1) == 'editor'
+      @ui.hideViewer()
     @initEditor(domEditor)
     @initFromURL()
     @byId(domEditor).addEventListener('keyup', ((e) => @onEditorKeyUp(e)), off)

--- a/sources/shdr/UI.coffee
+++ b/sources/shdr/UI.coffee
@@ -15,6 +15,11 @@ class UI
     @initBoxes()
     @resetLoadFiles()
 
+  hideViewer: ->
+    $('#panel-right').fadeOut(100)
+    $('#panel-left').css('right', '0%')
+    $('#mid-separator').css('left', '100%')
+
   hideMainLoader: ->
     $('#main-loader').fadeOut(400)
 


### PR DESCRIPTION
The model preview is hidden when the `?editor` URL parameter is given.
The editor then takes up the entire width of the screen.

#5 

![screen shot 2016-12-20 at 11 15 10 pm](https://cloud.githubusercontent.com/assets/2614746/21380448/39aae27a-c70a-11e6-9f04-b3977284fbd9.png)
